### PR TITLE
Зомби не регенятся от КПБ 

### DIFF
--- a/Content.Server/Zombies/ZombieSystem.cs
+++ b/Content.Server/Zombies/ZombieSystem.cs
@@ -11,6 +11,8 @@ using Content.Shared.Bed.Sleep;
 using Content.Shared.Body.Systems;
 using Content.Shared.Cloning.Events;
 using Content.Shared.Chat;
+using Content.Shared.Damage.Components; // DS14
+using Content.Shared.Damage.Prototypes; // DS14
 using Content.Shared.Damage.Systems;
 using Content.Shared.Humanoid;
 using Content.Shared.Inventory;
@@ -35,6 +37,10 @@ namespace Content.Server.Zombies
 {
     public sealed partial class ZombieSystem : SharedZombieSystem
     {
+        // DS14-start
+        private static readonly ProtoId<DamageContainerPrototype> SiliconDamageContainer = "Silicon";
+        // DS14-end
+
         [Dependency] private readonly IGameTiming _timing = default!;
         [Dependency] private readonly IPrototypeManager _protoManager = default!;
         [Dependency] private readonly IRobustRandom _random = default!;
@@ -265,6 +271,12 @@ namespace Content.Server.Zombies
 
                 if (_mobState.IsAlive(uid, mobState))
                 {
+                    // DS14-start
+                    if (TryComp<DamageableComponent>(uid, out var damageable) &&
+                        damageable.DamageContainerID == SiliconDamageContainer)
+                        continue;
+                    // DS14-end
+
                     _damageable.TryChangeDamage(args.User, entity.Comp.HealingOnBite, true, false);
 
                     // If we cannot infect the living target, the zed will just heal itself.

--- a/Content.Shared/Damage/Systems/SharedStaminaSystem.cs
+++ b/Content.Shared/Damage/Systems/SharedStaminaSystem.cs
@@ -255,7 +255,10 @@ public abstract partial class SharedStaminaSystem : EntitySystem
     /// <summary>
     /// Tries to take stamina damage without raising the entity over the crit threshold.
     /// </summary>
-    public bool TryTakeStamina(EntityUid uid, float value, StaminaComponent? component = null, EntityUid? source = null, EntityUid? with = null, bool visual = false)
+    // DS14-start
+    public bool TryTakeStamina(EntityUid uid, float value, StaminaComponent? component = null, EntityUid? source = null,
+        EntityUid? with = null, bool visual = false, bool ignoreResist = false)
+    // DS14-end
     {
         // Something that has no Stamina component automatically passes stamina checks
         if (!Resolve(uid, ref component, false))
@@ -266,7 +269,9 @@ public abstract partial class SharedStaminaSystem : EntitySystem
         if (oldStam + value >= component.CritThreshold || component.Critical)
             return false;
 
-        TakeStaminaDamage(uid, value, component, source, with, visual: visual);
+        // DS14-start
+        TakeStaminaDamage(uid, value, component, source, with, visual: visual, ignoreResist: ignoreResist);
+        // DS14-end
         return true;
     }
 

--- a/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
+++ b/Content.Shared/Stunnable/SharedStunSystem.Knockdown.cs
@@ -379,10 +379,14 @@ public abstract partial class SharedStunSystem
         return !ev.Cancelled;
     }
 
-    private bool StandingBlocked(Entity<KnockedDownComponent> entity)
+    // DS14-start
+    private bool StandingBlocked(Entity<KnockedDownComponent> entity, bool force = false)
+    // DS14-end
     {
-        if (!TryStand(entity))
+        // DS14-start
+        if (force ? !CanForceStandNow(entity) : !TryStand(entity))
             return true;
+        // DS14-end
 
         if (!IntersectingStandingColliders(entity.Owner))
             return false;
@@ -392,6 +396,27 @@ public abstract partial class SharedStunSystem
         return true;
 
     }
+
+    // DS14-start
+    private bool CanForceStandNow(Entity<KnockedDownComponent> entity)
+    {
+        // Damage extends NextUpdate to interrupt normal standing. A force stand still respects
+        // movement blockers, but deliberately ignores that extension.
+        if (!Blocker.CanMove(entity))
+            return false;
+
+        var ev = new StandUpAttemptEvent(entity.Comp.AutoStand);
+        RaiseLocalEvent(entity, ref ev);
+
+        if (ev.Autostand != entity.Comp.AutoStand)
+            SetAutoStand((entity.Owner, entity.Comp), ev.Autostand);
+
+        if (ev.Message != null)
+            _popup.PopupClient(ev.Message.Value.Item1, entity, entity, ev.Message.Value.Item2);
+
+        return !ev.Cancelled;
+    }
+    // DS14-end
 
     private void OnForceStandup(ForceStandUpEvent msg, EntitySessionEventArgs args)
     {
@@ -409,8 +434,10 @@ public abstract partial class SharedStunSystem
         // That way if we fail to stand, the game will try to stand for us when we are able to
         SetAutoStand(entity, true);
 
-        if (StandingBlocked((entity, entity.Comp)))
+        // DS14-start
+        if (StandingBlocked((entity, entity.Comp), force: true))
             return;
+        // DS14-end
 
         if (!_hands.TryGetEmptyHand(entity.Owner, out _))
             return;
@@ -452,7 +479,9 @@ public abstract partial class SharedStunSystem
         var ev = new TryForceStandEvent(entity.Comp.ForceStandStamina);
         RaiseLocalEvent(entity, ref ev);
 
-        if (!Stamina.TryTakeStamina(entity, ev.Stamina, entity.Comp, visual: true))
+        // DS14-start
+        if (!Stamina.TryTakeStamina(entity, ev.Stamina, entity.Comp, visual: true, ignoreResist: true))
+        // DS14-end
         {
             _popup.PopupClient(Loc.GetString("knockdown-component-pushup-failure"), entity, entity, PopupType.MediumCaution);
             return false;


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. ТЕКСТ МЕЖДУ СТРЕЛКАМИ - ЭТО КОММЕНТАРИИ, ОНИ НЕ БУДУТ ВИДНЫ В ОПИСАНИИ PR. -->

## Ссылка на задачу
<!--Укажите ссылки на соответствующие обсуждения, предложение, задачу. -->

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [ ] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [ ] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [ ] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [ ] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
В журнал изменений следует помещать только то, что действительно важно игрокам. Если вы добавили музыку для ивента - это не важно. 
Если вы понёрфили пули христова - это важно. Убедитесь, что вы вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. -->
:cl:
- Изменено: Теперь можно встать резко на ПКМ в любом случае, однако идёт игнорирование стамина защиты при поднятии. Имеется ввиду что теперь пока в вас стреляют, можно встать резко на ПКМ, раньше нельзя было так сделать.
- Исправлено: Зомби теперь не могут лечится при укусе синтетиков
