### PR TITLE
Slow Ash

### DIFF
--- a/Resources/Prototypes/_DeadSpace/Lavaland/AshWalkers/ash_walkers.yml
+++ b/Resources/Prototypes/_DeadSpace/Lavaland/AshWalkers/ash_walkers.yml
@@ -23,6 +23,10 @@
   - type: TemperatureDamage
     heatDamageThreshold: 500
     coldDamageThreshold: 260
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      120: 0.7
+      160: 0.5
   - type: TemperatureSpeed
     thresholds:
       260: 0.9


### PR DESCRIPTION

:cl:

- Исправлено: У Пеплоходцев теперь замедление работает по собственным корректным значениям: 30% при 120 скорости и 50% при 160. А не наследуется от МакУриста.

