### PR TITLE
 Slow Ash aaaa cyka

### DIFF
--- a/Resources/Prototypes/_DeadSpace/Lavaland/AshWalkers/ash_walkers.yml
+++ b/Resources/Prototypes/_DeadSpace/Lavaland/AshWalkers/ash_walkers.yml
@@ -28,6 +28,10 @@
       260: 0.9
       240: 0.8
       220: 0.7
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      120: 0.7
+      160: 0.5
   - type: Damageable
     damageModifierSet: AshWalker
   - type: MobThresholds


### PR DESCRIPTION

:cl:

- Исправлено: У Пеплоходцев теперь замедление работает по собственным корректным значениям: 30% при 120 скорости и 50% при 160. А не наследуется от МакУриста.

