### PR TITLE
Спрайт одноствольного багета на спине 

### DIFF
--- a/Content.Shared/Weapons/Melee/EnergySword/EnergySwordComponent.cs
+++ b/Content.Shared/Weapons/Melee/EnergySword/EnergySwordComponent.cs
@@ -22,7 +22,12 @@ public sealed partial class EnergySwordComponent : Component
         Color.DodgerBlue,
         Color.Aqua,
         Color.MediumSpringGreen,
-        Color.MediumOrchid
+        Color.MediumOrchid,
+        Color.Gold,
+        Color.LimeGreen,
+        Color.DarkOrange,
+        Color.MediumTurquoise,
+        Color.White
     };
 
     /// <summary>


### PR DESCRIPTION
<!-- ЭТО ШАБЛОН ВАШЕГО PULL REQUEST. ТЕКСТ МЕЖДУ СТРЕЛКАМИ - ЭТО КОММЕНТАРИИ, ОНИ НЕ БУДУТ ВИДНЫ В ОПИСАНИИ PR. -->

## Ссылка на задачу
<!--Укажите ссылки на соответствующие обсуждения, предложение, задачу. -->

## Медиа
<!-- Прикрепите медиафайлы, если PR вносит изменения в игру (одежда, предметы, механики и т.д.).
Небольшие исправления/рефакторинг освобождаются от этого требования. -->

## Требования
<!-- Подтвердите следующее, поставив X в скобках [X]: -->
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует.

## Критические изменения
<!-- Перечислите все критические изменения, включая изменения пространств имен, публичных классов/методов/полей, переименования прототипов; и предоставьте инструкции по их исправлению. -->

**Список изменений**
<!-- Добавьте запись в Changelog, чтобы игроки знали о новых функциях или изменениях, которые могут повлиять на игровой процесс.
В журнал изменений следует помещать только то, что действительно важно игрокам. Если вы добавили музыку для ивента - это не важно. 
Если вы понёрфили пули христова - это важно. Убедитесь, что вы вынесли этот шаблон Changelog из блока комментариев, чтобы он отображался.
Changelog должен иметь символ :cl:, чтобы бот распознал изменения и добавил их в список изменений игры. --> Раньше был спрайт двухстволки. Я думал не доделали спрайты. Оказывается - там просто не был указан компонент Clothing, ведущий на неиспользуемые спрайты. Добавил компонент парой строчек, теперь всё исправно. 
:cl:
- Исправлено:  Отображение одноствольного дробовика-багета на спине. Теперь, вместо двухстволки там реально багет.
<img width="402" height="533" alt="image" src="https://github.com/user-attachments/assets/553b9c73-9a9a-4831-ac3b-9221c6a1230c" />
